### PR TITLE
Fix a bug when calling internal_resource.get_from_list not passing the argument sparql_endpoint

### DIFF
--- a/src/linkeddata_api/vocab_viewer/nrm/internal_resource.py
+++ b/src/linkeddata_api/vocab_viewer/nrm/internal_resource.py
@@ -10,7 +10,6 @@ def _get_from_list_query(uris: list[str]) -> str:
         SELECT distinct ?uri ?internal
         WHERE {
             VALUES (?uri) {
-                (<http://example.com>)
                 {% for uri in uris %}
                 (<{{ uri }}>)
                 {% endfor %}

--- a/src/linkeddata_api/vocab_viewer/nrm/resource.py
+++ b/src/linkeddata_api/vocab_viewer/nrm/resource.py
@@ -140,7 +140,7 @@ def get(uri: str, sparql_endpoint: str) -> nrm.schema.Resource:
 
         label = nrm.label.get(uri, sparql_endpoint) or uri
 
-        uri_internal_index = nrm.internal_resource.get_from_list(uri_values)
+        uri_internal_index = nrm.internal_resource.get_from_list(uri_values, sparql_endpoint)
 
         if not uri_internal_index.get(uri):
             raise nrm.exceptions.SPARQLNotFoundError(


### PR DESCRIPTION
This PR also removes a dev value in the SPARQL query.