### PR TITLE
Improve rendering instances with large number of predicates

### DIFF
--- a/src/linkeddata_api/data/sparql.py
+++ b/src/linkeddata_api/data/sparql.py
@@ -1,8 +1,10 @@
 import requests
 
 from . import exceptions
+from linkeddata_api.log_time import log_time
 
 
+@log_time
 def post(
     query: str, sparql_endpoint: str, accept: str = "application/sparql-results+json"
 ) -> requests.Response:
@@ -21,7 +23,9 @@ def post(
         "content-type": "application/sparql-query",
     }
 
-    response = requests.post(url=sparql_endpoint, headers=headers, data=query, timeout=60)
+    response = requests.post(
+        url=sparql_endpoint, headers=headers, data=query, timeout=60
+    )
 
     try:
         response.raise_for_status()
@@ -51,7 +55,9 @@ def get(
     }
     params = {"query": query}
 
-    response = requests.get(url=sparql_endpoint, headers=headers, params=params, timeout=60)
+    response = requests.get(
+        url=sparql_endpoint, headers=headers, params=params, timeout=60
+    )
 
     try:
         response.raise_for_status()

--- a/src/linkeddata_api/domain/curie.py
+++ b/src/linkeddata_api/domain/curie.py
@@ -16,6 +16,8 @@ prefixes = {
     "https://w3id.org/tern/ontologies/tern/": "tern",
     "http://www.w3.org/2002/07/owl#": "owl",
     "http://www.w3.org/2001/XMLSchema#": "xsd",
+    "http://rdfs.org/ns/void#": "void",
+    "http://www.w3.org/ns/prov#": "prov",
 }
 
 # Don't find curies for these - speeds up request processing.


### PR DESCRIPTION
These changes improve query performance and large instances with very large lists of predicates such as http://linked.data.gov.au/dataset/ausplots/sv-53488 no longer fail to render (though it still takes a while to render, ~60 seconds).

The new SPARQL query is also much smaller than previously due to the use of `VALUES` for each predicate's object. This reduced SPARQL query size may have also inadvertently fixed issue https://github.com/ternaustralia/linkeddata-api/issues/37.