### PR TITLE
Moved `Module Overview` in method vocabulary to the first section

### DIFF
--- a/src/linkeddata_api/domain/viewer/resource/json/profiles/custom_profiles.py
+++ b/src/linkeddata_api/domain/viewer/resource/json/profiles/custom_profiles.py
@@ -26,12 +26,12 @@ class MethodCollectionProfile(Profile):
         self._add_and_remove_property(str(TERN), properties, new_properties)
         self._add_and_remove_property(str(SDO.url), properties, new_properties)
         self._add_and_remove_property(str(SKOS.memberList), properties, new_properties)
-        self._add_and_remove_property(str(TERN.scope), properties, new_properties)
-        self._add_and_remove_property(str(SKOS.definition), properties, new_properties)
-        self._add_and_remove_property(str(TERN.purpose), properties, new_properties)
         self._add_and_remove_property(
             str(DCTERMS.description), properties, new_properties
         )
+        self._add_and_remove_property(str(TERN.scope), properties, new_properties)
+        self._add_and_remove_property(str(SKOS.definition), properties, new_properties)
+        self._add_and_remove_property(str(TERN.purpose), properties, new_properties)
         self._add_and_remove_property(str(TERN.equipment), properties, new_properties)
         self._add_and_remove_property(
             str(TERN.instructions), properties, new_properties

--- a/src/linkeddata_api/views/api_v2/viewer/profile/custom_profiles.py
+++ b/src/linkeddata_api/views/api_v2/viewer/profile/custom_profiles.py
@@ -26,12 +26,12 @@ class MethodCollectionProfile(Profile):
 
         self._add_and_remove_property(str(SDO.url), properties, new_properties)
         self._add_and_remove_property(str(SKOS.memberList), properties, new_properties)
-        self._add_and_remove_property(str(TERN.scope), properties, new_properties)
-        self._add_and_remove_property(str(SKOS.definition), properties, new_properties)
-        self._add_and_remove_property(str(TERN.purpose), properties, new_properties)
         self._add_and_remove_property(
             str(DCTERMS.description), properties, new_properties
         )
+        self._add_and_remove_property(str(TERN.scope), properties, new_properties)
+        self._add_and_remove_property(str(SKOS.definition), properties, new_properties)
+        self._add_and_remove_property(str(TERN.purpose), properties, new_properties)
         self._add_and_remove_property(str(TERN.equipment), properties, new_properties)
         self._add_and_remove_property(
             str(TERN.instructions), properties, new_properties


### PR DESCRIPTION
In EMSA field survey protocols (DCCEEW project), `Module Overview` was after the `Rationale`, but in latest versions, it comes to the first section. This PR updated the order of sections in methods vocabulary to be consistent with the surveillance team.